### PR TITLE
refactor: simplify md5 helper

### DIFF
--- a/util.go
+++ b/util.go
@@ -47,13 +47,9 @@ func callJobFuncWithParams(jobFunc interface{}, params []interface{}) []reflect.
 	return f.Call(in)
 }
 
-// getMD5Hash use md5 to encode string
-// #nosec
-func getMD5Hash(str string) (error, string) {
-	h := md5.New()
-	_, err := h.Write([]byte(str))
-	if err != nil {
-		return err, ""
-	}
-	return nil, hex.EncodeToString(h.Sum(nil))
+// getMD5Hash encodes the given string with md5 and returns the hex string.
+// #nosec G401 - md5 is acceptable here for non-cryptographic hashing
+func getMD5Hash(str string) string {
+	sum := md5.Sum([]byte(str))
+	return hex.EncodeToString(sum[:])
 }


### PR DESCRIPTION
## Summary
- simplify MD5 helper to use sum and drop error return
- streamline gravatar check to avoid unnecessary reads

## Testing
- `go test ./...` (fails: Get "https://www.gravatar.com/avatar/6cd51cd9d94cc3aa72b6e9d18d5df0c3?d=404": Forbidden)
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_689251b5a158832093129bcb091bb74d