### PR TITLE
Add SPF and DMARC DNS record validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Email Address Validation: validates if a string contains a valid email.
 - Email Verification Lookup via SMTP: performs an email verification on the passed email (catchAll detection enabled by default)
 - MX Validation: checks the DNS MX records for the given domain name
+- SPF & DMARC Validation: checks the domain's SPF and DMARC DNS records
 - Misc Validation: including Free email provider check, Role account validation, Disposable emails address (DEA) validation
 - Email Reachability: checks how confident in sending an email to the address
 
@@ -66,16 +67,18 @@ func main() {
 			"reachable":"unknown",
 			"role_account":false,
 			"free":false,
-			"syntax":{
-			"username":"example",
-				"domain":"exampledomain.org",
-				"valid":true
-			},
-			"has_mx_records":true,
-			"smtp":null,
-			"gravatar":null
-		}
-	*/
+                        "syntax":{
+                        "username":"example",
+                                "domain":"exampledomain.org",
+                                "valid":true
+                        },
+                        "has_mx_records":true,
+                        "spf_valid":false,
+                        "dmarc_valid":false,
+                        "smtp":null,
+                        "gravatar":null
+                }
+        */
 }
 ```
 

--- a/dns_records.go
+++ b/dns_records.go
@@ -1,0 +1,36 @@
+package emailverifier
+
+import (
+	"net"
+	"strings"
+)
+
+// CheckSPF checks if the domain has a valid SPF record.
+func (v *Verifier) CheckSPF(domain string) bool {
+	domain = domainToASCII(domain)
+	records, err := net.LookupTXT(domain)
+	if err != nil {
+		return false
+	}
+	for _, record := range records {
+		if strings.HasPrefix(strings.ToLower(record), "v=spf1") {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckDMARC checks if the domain has a valid DMARC record.
+func (v *Verifier) CheckDMARC(domain string) bool {
+	domain = domainToASCII(domain)
+	records, err := net.LookupTXT("_dmarc." + domain)
+	if err != nil {
+		return false
+	}
+	for _, record := range records {
+		if strings.HasPrefix(strings.ToLower(record), "v=dmarc1") {
+			return true
+		}
+	}
+	return false
+}

--- a/verifier.go
+++ b/verifier.go
@@ -35,6 +35,8 @@ type Result struct {
 	RoleAccount  bool      `json:"role_account"`   // is account a role-based account
 	Free         bool      `json:"free"`           // is domain a free email domain
 	HasMxRecords bool      `json:"has_mx_records"` // whether or not MX-Records for the domain
+	SPFValid     bool      `json:"spf_valid"`      // whether domain has valid SPF record
+	DMARCValid   bool      `json:"dmarc_valid"`    // whether domain has valid DMARC record
 }
 
 // additional list of disposable domains set via users of this library
@@ -87,6 +89,9 @@ func (v *Verifier) Verify(email string) (*Result, error) {
 		return &ret, err
 	}
 	ret.HasMxRecords = mx.HasMXRecord
+
+	ret.SPFValid = v.CheckSPF(syntax.Domain)
+	ret.DMARCValid = v.CheckDMARC(syntax.Domain)
 
 	smtp, err := v.CheckSMTP(syntax.Domain, syntax.Username)
 	if err != nil {

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -24,6 +24,8 @@ func TestCheckEmailOK_SMTPHostNotExists(t *testing.T) {
 			Valid:    true,
 		},
 		HasMxRecords: false,
+		SPFValid:     false,
+		DMARCValid:   false,
 		Disposable:   false,
 		RoleAccount:  false,
 		Reachable:    reachableUnknown,
@@ -43,6 +45,9 @@ func TestCheckEmailOK_SMTPHostExists_NotCatchAll(t *testing.T) {
 		email    = address
 	)
 
+	spfValid := verifier.CheckSPF(domain)
+	dmarcValid := verifier.CheckDMARC(domain)
+
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
@@ -52,6 +57,8 @@ func TestCheckEmailOK_SMTPHostExists_NotCatchAll(t *testing.T) {
 			Valid:    true,
 		},
 		HasMxRecords: true,
+		SPFValid:     spfValid,
+		DMARCValid:   dmarcValid,
 		Reachable:    reachableUnknown,
 		Disposable:   false,
 		RoleAccount:  false,
@@ -77,6 +84,9 @@ func TestCheckEmailOK_SMTPHostExists_FreeDomain(t *testing.T) {
 		email    = address
 	)
 
+	spfValid := verifier.CheckSPF(domain)
+	dmarcValid := verifier.CheckDMARC(domain)
+
 	ret, err := verifier.Verify(email)
 	expected := Result{
 		Email: email,
@@ -86,6 +96,8 @@ func TestCheckEmailOK_SMTPHostExists_FreeDomain(t *testing.T) {
 			Valid:    true,
 		},
 		HasMxRecords: true,
+		SPFValid:     spfValid,
+		DMARCValid:   dmarcValid,
 		Reachable:    reachableNo,
 		Disposable:   false,
 		RoleAccount:  false,
@@ -120,6 +132,8 @@ func TestCheckEmail_ErrorSyntax(t *testing.T) {
 			Valid:    false,
 		},
 		HasMxRecords: false,
+		SPFValid:     false,
+		DMARCValid:   false,
 		Reachable:    reachableUnknown,
 		Disposable:   false,
 		RoleAccount:  false,
@@ -148,6 +162,8 @@ func TestCheckEmail_Disposable(t *testing.T) {
 			Valid:    true,
 		},
 		HasMxRecords: false,
+		SPFValid:     false,
+		DMARCValid:   false,
 		Reachable:    reachableUnknown,
 		Disposable:   true,
 		RoleAccount:  false,


### PR DESCRIPTION
## Summary
- add SPF and DMARC TXT record lookup utilities
- report SPFValid and DMARCValid in verification results
- document SPF/DMARC fields in README

## Testing
- `go test ./...` *(fails: Get "https://www.gravatar.com/avatar/6cd51cd9d94cc3aa72b6e9d18d5df0c3?d=404": Forbidden)*
- `pre-commit run --files dns_records.go verifier.go verifier_test.go README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689254a36744832094f7f6db345e61b7